### PR TITLE
Authenticate using server ClientId

### DIFF
--- a/LockGoogle/A0GoogleAuthenticator.h
+++ b/LockGoogle/A0GoogleAuthenticator.h
@@ -29,6 +29,13 @@
 @interface A0GoogleAuthenticator : A0BaseAuthenticator
 
 /**
+ * Your server's clientId obtained from Google. 
+ * Set this value if you need to use the user's token in your server so all tokens are issued to be used by your backemd
+ * By default is nil.
+ */
+@property (copy, nonatomic) NSString *serverClientId;
+
+/**
  *  Creates a new authenticator with default scopes (login and email) and a clientId.
  *  It will retrieve Google's clientId from `GoogleService-Info.plist` file
  *

--- a/LockGoogle/A0GoogleAuthenticator.m
+++ b/LockGoogle/A0GoogleAuthenticator.m
@@ -81,6 +81,7 @@ NSString * const DefaultConnectionName = @"google-oauth2";
     NSAssert(failure != nil, @"Must provide a non-nil failure block");
     A0APIClient *client = [self apiClient];
     NSString *connectionName = [self identifier];
+    self.google.serverClientId = self.serverClientId;
     [self.google authenticateWithScopes:[self scopesFromParameters:parameters] callback:^(NSError *error, NSString *token) {
         if (error) {
             A0LogError(@"Failed to authenticate with Google with error %@", error);

--- a/LockGoogle/A0GoogleProvider.h
+++ b/LockGoogle/A0GoogleProvider.h
@@ -28,6 +28,8 @@ typedef void(^A0GoogleAuthentication)(NSError * __nullable error, NSString * __n
 
 @interface A0GoogleProvider : NSObject
 
+@property (copy, nonatomic) NSString *serverClientId;
+
 - (instancetype)initWithScopes:(NSArray *)scopes;
 - (instancetype)initWithClientId:(NSString *)clientId scopes:(NSArray *)scopes;
 

--- a/LockGoogle/A0GoogleProvider.m
+++ b/LockGoogle/A0GoogleProvider.m
@@ -67,6 +67,7 @@
     if (scopes.count > 0) {
         self.authentication.scopes = scopes;
     }
+    self.authentication.serverClientID = self.serverClientId;
     self.onAuthentication = callback;
     A0LogVerbose(@"Authenticating with Google with clientId %@, scopes %@", self.authentication.clientID, self.authentication.scopes);
     [self.authentication signIn];

--- a/LockGoogleTests/A0GoogleAuthenticatorSpec.m
+++ b/LockGoogleTests/A0GoogleAuthenticatorSpec.m
@@ -80,6 +80,8 @@ describe(@"authenticate", ^{
     __block A0AuthParameters *parameters;
 
     beforeEach(^{
+        authenticator = [[A0GoogleAuthenticator alloc] initWithConnectionName:kDefaultConnectionName andGoogleProvider:google];
+        authenticator.clientProvider = clientProvider;
         googleToken = [[NSUUID UUID] UUIDString];
         parameters = [A0AuthParameters newDefaultParams];
     });
@@ -89,6 +91,15 @@ describe(@"authenticate", ^{
                                           success:^(A0UserProfile *profile, A0Token *token) {}
                                           failure:^(NSError *error){}];
         [MKTVerify(google) authenticateWithScopes:nil callback:HC_notNilValue()];
+    });
+
+    it(@"should pass along server clientid", ^{
+        NSString *serverClientId = @"Server ClientId";
+        authenticator.serverClientId = serverClientId;
+        [authenticator authenticateWithParameters:parameters
+                                          success:^(A0UserProfile *profile, A0Token *token) {}
+                                          failure:^(NSError *error){}];
+        [MKTVerify(google) setServerClientId:serverClientId];
     });
 
     it(@"should send connection scopes in parameters", ^{

--- a/LockGoogleTests/A0GoogleProviderSpec.m
+++ b/LockGoogleTests/A0GoogleProviderSpec.m
@@ -117,7 +117,6 @@ describe(@"authenticate", ^{
             [google authenticateWithScopes:nil callback:^(NSError *error, NSString *token) {}];
             [MKTVerifyCount(authentication, MKTTimes(1)) setScopes:HC_anything()];
         });
-
     });
 
     context(@"with scopes", ^{
@@ -132,6 +131,21 @@ describe(@"authenticate", ^{
         it(@"should not set scopes", ^{
             [google authenticateWithScopes:scopes callback:^(NSError *error, NSString *token) {}];
             [MKTVerify(authentication) setScopes:scopes];
+        });
+    });
+
+    context(@"with server clientId", ^{
+        it(@"should start flow", ^{
+            google.serverClientId = @"Server ClientId";
+            [google authenticateWithScopes:nil callback:^(NSError *error, NSString *token) {}];
+            [MKTVerify(authentication) signIn];
+        });
+
+        it(@"should set serverClientId", ^{
+            NSString *serverClientId = @"Server ClientId";
+            google.serverClientId = serverClientId;
+            [google authenticateWithScopes:nil callback:^(NSError *error, NSString *token) {}];
+            [MKTVerify(authentication) setServerClientID:serverClientId];
         });
 
     });
@@ -149,7 +163,6 @@ describe(@"authenticate", ^{
                 [google cancelAuthentication];
             });
         });
-
     });
 
     context(@"when signIn:didSigninForUser:withError called", ^{


### PR DESCRIPTION
This will allow to obtain a JWT from Google with the claim `aud` set for the server application instead of the mobile application (the default behaviour).
